### PR TITLE
fix: requests session POST retries

### DIFF
--- a/app/src/project/core/views.py
+++ b/app/src/project/core/views.py
@@ -25,6 +25,7 @@ retries = Retry(
     backoff_factor=0.1,
     status_forcelist=(),
     raise_on_status=False,
+    allowed_methods=False,  # default excludes POST; False retries all methods (safe here since Prometheus remote write is idempotent)
 )
 
 TIMEOUT = 15


### PR DESCRIPTION
The `prometheus_outbound_proxy` view is using a module-level `requests.Session` with connection pooling. The central proxy closes keep-alive connections after being idle, but the pooled connection stays in the session. When Prometheus fires a scrape 2-5 times a day at just the right moment, the stale pooled connection gets reused and the remote end has already closed it → RemoteDisconnected.

Retries did not help because by default `POST` is excluded from `allowed_methods`

**Issue:** NEX-2